### PR TITLE
Fix theme-toggle transition gap and add missing nav links

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -270,6 +270,10 @@ body,
   height: 100%;
 }
 
+/* Only the old snapshot animates (shrinking away in a circle around the
+   toggle). The new snapshot stays fully visible underneath the whole time —
+   animating both independently left a gap between the shrinking and growing
+   circles (most visible on the side of the screen opposite the toggle). */
 ::view-transition-old(root) {
   z-index: 2;
   animation-name: atmos-theme-circle-in;
@@ -277,16 +281,6 @@ body,
 
 ::view-transition-new(root) {
   z-index: 1;
-  animation-name: atmos-theme-circle-out;
-}
-
-@keyframes atmos-theme-circle-out {
-  from {
-    clip-path: circle(0px at var(--reveal-x) var(--reveal-y));
-  }
-  to {
-    clip-path: circle(var(--reveal-radius) at var(--reveal-x) var(--reveal-y));
-  }
 }
 
 @keyframes atmos-theme-circle-in {

--- a/src/components/Nav.css
+++ b/src/components/Nav.css
@@ -383,7 +383,10 @@
 }
 
 /* ── Responsive ─────────────────────────────────────────── */
-@media (max-width: 1024px) {
+/* Raised from 1024px: the nav now has 8 links, and the absolutely-centered
+   link pill (see .atmos-nav-center) can overlap the CTA/theme toggle on the
+   right before 1024px width is reached. 1200px keeps a safe margin. */
+@media (max-width: 1200px) {
   .atmos-nav {
     height: 64px;
   }

--- a/src/constants/nav.js
+++ b/src/constants/nav.js
@@ -2,6 +2,8 @@ export const NAV_ITEMS = [
   { to: "/seminars", label: "Events" },
   { to: "/projects", label: "Projects" },
   { to: "/resources", label: "Resources" },
+  { to: "/sandbox", label: "Sandbox" },
+  { to: "/pitch", label: "Pitch Builder" },
   { to: "/leadership", label: "Leadership" },
   { to: "/involvement", label: "Get Involved" },
   { to: "/contact", label: "Contact" },


### PR DESCRIPTION
The circular reveal animation clipped both the old and new view-transition snapshots independently (old shrinking, new growing), which left a blank/uncovered ring between them mid-animation — most visible on the side of the screen opposite the toggle button (reported as a glitch on the left half). Now only the old snapshot animates; the new one stays fully visible underneath so the reveal has no gap.

Also linked the fully-built /sandbox and /pitch pages, which existed as routes but were never added to NAV_ITEMS and so were unreachable from the site. Raised the nav's mobile-burger breakpoint from 1024px to 1200px since the extra links otherwise overlap the CTA/theme toggle at medium widths.